### PR TITLE
Fix historical sync restarting from scratch every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Built-in energy dashboard is also supported:
 
 - **Custom Fortum dashboard strategy**: Provides a dedicated Fortum dashboard that combines Energy Dashboard-style itemization with Fortum provider insights (spot price and temperature), includes a separate tomorrow-price graph, and keeps hourly-level statistics for deeper analysis.
 - **Visual dashboard editor**: Configure single and multipoint dashboard strategy options directly in the Home Assistant dashboard editor without manual YAML edits.
-- **Hourly historical statistics**: Imports hourly consumption, cost, price, and temperature and backfills missing history on a regular interval.
+- **Hourly historical statistics**: Imports hourly consumption, cost, price, and temperature and backfills missing history every 30 minutes.
 - **Full available history**: Historical sync covers the entire period Fortum exposes for your metering point, which is often multiple years.
 - **Energy Dashboard compatible**: Imported hourly consumption and cost are written as Home Assistant long-term statistics for Energy Dashboard and historical charts.
 - **Multi-meter support**: Creates separate statistics series for each metering point found in your Fortum account.
@@ -74,10 +74,10 @@ For manual Energy setup, add Fortum hourly statistics under Grid consumption:
 
 ## Initial Sync Behavior
 
-- On first start, the integration performs a full historical sync for each discovered metering point.
-- The full sync covers all hourly history available from Fortum (often years).
-- Expect initial history sync to take up to **5 minutes per year** of available data.
-- Integration entities become available after this initial history sync completes.
+- On first start, the integration begins a historical sync for each discovered metering point.
+- The sync covers all hourly history available from Fortum (often years), processed in two-week chunks.
+- A single sync run processes up to about 4 years of history; any remainder is picked up on subsequent runs every 30 minutes.
+- Integration entities become available as the sync reaches their data. Most entities appear after the first sync run; current-month sensors appear once the sync reaches the current month.
 
 ## Entities
 

--- a/custom_components/fortum/api/client.py
+++ b/custom_components/fortum/api/client.py
@@ -419,11 +419,27 @@ class FortumAPIClient:
                 )
                 return two_weeks_ago, True
 
+            # A previous sync may have made progress beyond earliest but
+            # not yet reached the recent window.  Check the full range so
+            # we resume where we left off instead of restarting.
+            latest_recorded = await self._find_latest_recorded_cost_stat_hour(
+                metering_point_no,
+                earliest,
+                two_weeks_ago,
+            )
+            if latest_recorded is not None:
+                resume_from = latest_recorded + timedelta(hours=1)
+                _LOGGER.info(
+                    "no cost statistics in recent window for %s; "
+                    "resuming historical sync from %s",
+                    metering_point_no,
+                    resume_from.isoformat(),
+                )
+                return resume_from, True
+
             _LOGGER.info(
-                "no cost statistics in [%s, %s) for %s; starting historical sync "
+                "no cost statistics for %s; starting historical sync "
                 "from earliest_hourly_available_at_utc=%s",
-                two_weeks_ago.isoformat(),
-                now.isoformat(),
                 metering_point_no,
                 earliest.isoformat(),
             )
@@ -497,6 +513,45 @@ class FortumAPIClient:
             return None
 
         return first_missing_hour - timedelta(hours=1)
+
+    async def _find_latest_recorded_cost_stat_hour(
+        self,
+        metering_point_no: str,
+        from_date: datetime,
+        to_date: datetime,
+    ) -> datetime | None:
+        """Return the latest recorded cost-stat hour in [from_date, to_date)."""
+        statistic_id = self._build_cost_statistic_id(metering_point_no)
+        try:
+            result = await get_instance(self._hass).async_add_executor_job(
+                lambda: statistics_during_period(
+                    self._hass,
+                    start_time=from_date,
+                    end_time=to_date,
+                    statistic_ids={statistic_id},
+                    period="hour",
+                    units=None,
+                    types={"sum"},
+                )
+            )
+        except Exception as exc:
+            _LOGGER.warning(
+                "could not read cost statistics for %s: %s",
+                statistic_id,
+                exc,
+            )
+            return None
+
+        rows = result.get(statistic_id) if result else None
+        if not rows:
+            return None
+
+        latest: datetime | None = None
+        for row in rows:
+            start = self._parse_stat_start(row.get("start"))
+            if start is not None and (latest is None or start > latest):
+                latest = start
+        return latest
 
     @staticmethod
     def _find_first_missing_hour(

--- a/tests/unit/api/test_client.py
+++ b/tests/unit/api/test_client.py
@@ -928,17 +928,24 @@ class TestFortumAPIClient:
     async def test_determine_hourly_data_sync_start_uses_userinfo_marker(
         self, mock_hass, mock_auth_client
     ):
-        """Use earliest marker from user info when no recent stats exist."""
+        """Use earliest marker from user info when no stats exist at all."""
         client = FortumAPIClient(mock_hass, mock_auth_client)
         cached_earliest = datetime.fromisoformat("2025-01-06T00:00:00+00:00")
         client._earliest_available_by_metering_point["6094111"] = cached_earliest
         two_weeks_ago = datetime.fromisoformat("2026-03-04T00:00:00+00:00")
         now = datetime.fromisoformat("2026-03-18T00:00:00+00:00")
 
-        with patch.object(
-            client,
-            "_find_last_recorded_cost_stat_hour",
-            return_value=None,
+        with (
+            patch.object(
+                client,
+                "_find_last_recorded_cost_stat_hour",
+                return_value=None,
+            ),
+            patch.object(
+                client,
+                "_find_latest_recorded_cost_stat_hour",
+                return_value=None,
+            ),
         ):
             start, historical = await client._determine_hourly_data_sync_start(
                 "6094111",
@@ -947,6 +954,38 @@ class TestFortumAPIClient:
             )
 
         assert start == cached_earliest
+        assert historical is True
+
+    async def test_determine_hourly_data_sync_start_resumes_from_previous_progress(
+        self, mock_hass, mock_auth_client
+    ):
+        """Resume from latest recorded stat when recent window is empty."""
+        client = FortumAPIClient(mock_hass, mock_auth_client)
+        cached_earliest = datetime.fromisoformat("2021-01-01T00:00:00+00:00")
+        client._earliest_available_by_metering_point["6094111"] = cached_earliest
+        two_weeks_ago = datetime.fromisoformat("2026-03-04T00:00:00+00:00")
+        now = datetime.fromisoformat("2026-03-18T00:00:00+00:00")
+        previous_frontier = datetime.fromisoformat("2024-12-26T23:00:00+00:00")
+
+        with (
+            patch.object(
+                client,
+                "_find_last_recorded_cost_stat_hour",
+                return_value=None,
+            ),
+            patch.object(
+                client,
+                "_find_latest_recorded_cost_stat_hour",
+                return_value=previous_frontier,
+            ),
+        ):
+            start, historical = await client._determine_hourly_data_sync_start(
+                "6094111",
+                two_weeks_ago,
+                now,
+            )
+
+        assert start == previous_frontier + timedelta(hours=1)
         assert historical is True
 
     async def test_backfill_stops_after_missing_price_gap(


### PR DESCRIPTION
Used Claude Code, have not read code changes fully. Seems to work for my own Fortum data.

# Summary
- Fix a bug where the historical statistics sync would restart from the earliest available date on every 30-minute run, never catching up to the present. This happened when total history exceeded ~4 years (104 two-week chunks), because the resume logic only checked the last 14 days for existing stats.
- When no recent stats are found, the sync now searches the full recorded range to find where the previous run left off and resumes from there.
- Update README Initial Sync Behavior section to accurately describe chunked sync behavior.

# Test plan
- Existing test_determine_hourly_data_sync_start_uses_userinfo_marker updated to mock new fallback path
- New test_determine_hourly_data_sync_start_resumes_from_previous_progress verifies resume from previous sync frontier
- All 37 client tests passing